### PR TITLE
Issue #23: Handle MSE errors by resetting source, part 1.

### DIFF
--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -51,6 +51,8 @@ export class PlayerWrapper {
     private currentSegment: IUISegment = null;
     private isPlaying: boolean = false;
     private _stallDetectionTimer: number | null = null;
+    private _firstVideoError: number = 0;
+    private _numVideoErrors: number = 0;
 
     private readonly OFFSET_MULTIPLAYER = 1000;
     private readonly SECONDS_IN_HOUR = 3600;
@@ -679,11 +681,48 @@ export class PlayerWrapper {
         return this.getClockTimeString(time, false);
     }
 
-    private onErrorEvent(event: shaka_player.PlayerEvents.ErrorEvent) {
+    private async onErrorEvent(event: shaka_player.PlayerEvents.ErrorEvent) {
         // Extract the shaka.util.Error object from the event.
         // eslint-disable-next-line no-console
         Logger.log(event.detail);
-        if (this.errorCallback) {
+
+        // If we encounter a video error, reset video source UNLESS we exceed
+        // max video errors within three minutes.
+        let errorHandled = false;
+        const assetUri = this.player.getAssetUri();
+        if (assetUri.startsWith('ws') && event.detail.code === shaka.util.Error.Code.VIDEO_ERROR) { // code 3016
+            const maxVideoErrors = 10; // Max retries will be 1 less than this number
+            const maxVideoErrorMinutes = 3;
+
+            const now = Date.now();
+            let secondsSinceFirstVideoError = (now - this._firstVideoError) / 1000;
+            if (secondsSinceFirstVideoError > 60 * maxVideoErrorMinutes) {
+                if (this._firstVideoError > 0) {
+                    Logger.log(`${secondsSinceFirstVideoError} elapsed since first video error, resetting count.`);
+                }
+                this._numVideoErrors = 0;
+                this._firstVideoError = now;
+                secondsSinceFirstVideoError = 0;
+            }
+
+            this._numVideoErrors += 1;
+            const logMsgPrefix = `Encountered ${this._numVideoErrors} video errors within the last ${secondsSinceFirstVideoError} seconds!`;
+            if (this._numVideoErrors >= maxVideoErrors) {
+                Logger.error(logMsgPrefix, 'No more reloads!');
+            } else {
+                Logger.log(logMsgPrefix, 'Reloading player.');
+                try {
+                    event.stopImmediatePropagation(); // Must call BEFORE await or else dispatch loop will keep notifying
+                    await this.load(assetUri);
+                    Logger.log('Reload complete!');
+                    errorHandled = true;
+                } catch (e) {
+                    Logger.error('Reload FAILED with error', JSON.stringify(e));
+                }
+            }
+        }
+
+        if (!errorHandled && this.errorCallback) {
             this.errorCallback(event);
             Logger.log(`onErrorEvent: ${event.detail}`);
         }

--- a/packages/web-components/src/player-component/shaka.ts
+++ b/packages/web-components/src/player-component/shaka.ts
@@ -560,7 +560,7 @@ export declare namespace shaka {
          * @description an interface defining events sent by shaka
          * @interface ShakaEvent
          */
-        export interface ShakaEvent {
+        export interface ShakaEvent extends Event {
             type: string;
         }
 
@@ -1182,6 +1182,11 @@ export declare namespace shaka {
 	  networking plugins.
 	   */
         getNetworkingEngine(): any;
+        /**
+       * @returnType Get the uri to the asset that the player has loaded.
+       * If the player has not loaded content, this will return <code>null</code>.
+        */
+        getAssetUri(): string;
         /**
 	   * @returnType If a manifest is loaded, returns the manifest URI given in
 	the last call to load().  Otherwise, returns null.


### PR DESCRIPTION
CR: See pull request.
Cross-reference: feature 10619548

The long-term home for this retry logic will be in the AvaPlayer class
of the ShakaRTSP repo, but until AvaWidgets moves to AvaPlayer, the code
which will go there needs to temporarily go in here first. We therefore
expect a part 2 commit which will undo this one.

Changes
1) When we receive a Shaka error callback, if we are playing live and
the error code is 3016 (VIDEO_ERROR, which we are commonly seeing as
VDA Error/PIPELINE_ERROR_DECODE, we will re-load the Shaka player up to
10 times within a three-minute window. This is generally enough to keep
going for quite some time, even in the face of continual decode
errors (I was able to go 25 minutes, for instance). The danger is if
buffering times are long (> 18 seconds), then 10 times in 3 minutes
could end up meaning infinite retry. We do not retry when playing
on-demand and for any other error codes than 3016.
2) As part of the error handling, we had to suppress further propagation
of the error event by calling stopImmediatePropagation (otherwise,
for example, the upper layers would stop playback and display an error
message). Extended the shaka.ts declarations to allow for this.
Long-term we should delete this file and use the declarations which ship
with Shaka.

Testing Procedure
1) Set up AVA endpoint against a b-frame camera stream (eg. Bosch). If
possible, modify the ShakaRTSP/media-stream-library to under-profile
the AVC1 codec to increase the chances of decode error. Run sample.html
against the AVA endpoint and confirm from console logs that we will
retry up to 10 times in a 3-minute window, and if we exceed this, we
stop trying and allow the error event to propagate, resulting in
playback stoppage and error message display.