### PR TITLE
PBI: 11033939: Fix RTSP Tunnelling URL

### DIFF
--- a/packages/common/services/media/media-api.class.ts
+++ b/packages/common/services/media/media-api.class.ts
@@ -32,7 +32,10 @@ export class MediaApi {
     public static getLiveStream(): string {
         // if RTSP is present use RTSP URL.
         if (this._liveStream && this.supportsMediaSource()) {
-            return this._liveStream;
+            const url = new URL(this._liveStream);
+            // getVideo API may one day return the RTSP URL, until then, hard-code it.
+            url.searchParams.append('rtsp', encodeURIComponent('rtsp://localhost'));
+            return url.toString();
         }
         const format = MediaApi._format === VideoFormat.HLS ? 'm3u8-cmaf' : 'mpd-time-cmaf';
         const extension = MediaApi._format === VideoFormat.HLS ? '.m3u8' : '.mpd';


### PR DESCRIPTION
CR: (pull request)

We are not currently passing an RTSP Url to the websocket proxy. In
these cases, the media-stream-library defaults to
rtsp://localhost/axis-media/media.amp.

Changes
1) Hard-code the RTSP Url to rtsp://localhost, rather than leaving it
undefined. The way it is plumbed is by appending a query to the wss
URL, with a key of 'rtsp' and a value which is the URL encoded RTSP Url.
It was done this way because the component which starts playback does
not have access to the RTSP plugin, only to Shaka, and so the only means
of communication is the URL.
2) In future, if we no longer use a hard-coded value of
rtsp://localhost, it is expected that the getVideo API would return
the RTSP Url which needs to be used. Where we hard-code rtsp://localhost
was selected with this in mind.

Testing Procedure
1) Npm run sample, browse to sample.html, fill in the fields and play a
video which has RTSP. Confirm via console logs that we now specify
rtsp://localhost instead of rtsp://localhost/axis-media/media.amp.
Verify that we can play RTSP successfully.