### PR TITLE
Do not display NaN in wallclock when RTCP SR is missing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,46 @@
   "requires": true,
   "dependencies": {
     "@azure/video-analyzer-player": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@azure/video-analyzer-player/-/video-analyzer-player-1.0.3.tgz",
-      "integrity": "sha512-+QSyuk34Pwd8eIsQDiGAvoB50eztaUiDQ1ahwPlxsr6QR47boSioowGHrjeQ0cObIp1j22mqMa71b6ShNlyZmw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@azure/video-analyzer-player/-/video-analyzer-player-1.0.4.tgz",
+      "integrity": "sha512-4E3S5BMuZc+RpENAkB4ZL1+0Mr8IPQf5uCllRQFTsaSEs1bcwE9D3qeP1xfPdJMI8DEgSEdiviuMwE+sEmemZg==",
       "requires": {
+        "@azure/media-stream-library": "*",
         "buffer": "^6.0.3",
-        "lva-rtsp-player": "*",
         "process": "^0.11.10",
         "shaka-player": "3.1.0"
       },
       "dependencies": {
+        "@azure/media-stream-library": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "buffer": "6.0.3",
+            "debug": "4.3.2",
+            "md5.js": "1.3.5",
+            "process": "0.11.10",
+            "stream-browserify": "3.0.0",
+            "ts-md5": "1.2.9",
+            "ws": "8.2.0"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "bundled": true
+        },
         "buffer": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "bundled": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "bundled": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "hash-base": {
@@ -33,28 +56,13 @@
             "safe-buffer": "^5.2.0"
           }
         },
+        "ieee754": {
+          "version": "1.2.1",
+          "bundled": true
+        },
         "inherits": {
           "version": "2.0.4",
           "bundled": true
-        },
-        "lva-rtsp-player": {
-          "version": "0.0.19",
-          "bundled": true,
-          "requires": {
-            "debug": "4.2.0",
-            "md5.js": "1.3.5",
-            "media-chrome": "^0.0.11",
-            "ws": "7.3.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.2.0",
-              "bundled": true,
-              "requires": {
-                "ms": "2.1.2"
-              }
-            }
-          }
         },
         "md5.js": {
           "version": "1.3.5",
@@ -65,12 +73,12 @@
             "safe-buffer": "^5.1.2"
           }
         },
-        "media-chrome": {
-          "version": "0.0.11",
-          "bundled": true
-        },
         "ms": {
           "version": "2.1.2",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.11.10",
           "bundled": true
         },
         "readable-stream": {
@@ -86,6 +94,14 @@
           "version": "5.2.1",
           "bundled": true
         },
+        "stream-browserify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.4",
+            "readable-stream": "^3.5.0"
+          }
+        },
         "string_decoder": {
           "version": "1.3.0",
           "bundled": true,
@@ -93,12 +109,16 @@
             "safe-buffer": "~5.2.0"
           }
         },
+        "ts-md5": {
+          "version": "1.2.9",
+          "bundled": true
+        },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true
         },
         "ws": {
-          "version": "7.3.1",
+          "version": "8.2.0",
           "bundled": true
         }
       }
@@ -10366,7 +10386,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/MediaWidgets/17dfdb49-6642-46a2-ab5c-9714aeee9144/_packaging/Media-AVA-Widgets/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+      "dev": true
     },
     "basic-auth": {
       "version": "1.1.0",
@@ -15419,7 +15440,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://pkgs.dev.azure.com/MediaWidgets/17dfdb49-6642-46a2-ab5c-9714aeee9144/_packaging/Media-AVA-Widgets/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -19835,7 +19857,8 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://pkgs.dev.azure.com/MediaWidgets/17dfdb49-6642-46a2-ab5c-9714aeee9144/_packaging/Media-AVA-Widgets/npm/registry/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "lodash-es": "^4.17.21",
         "rxjs": "^6.6.3",
         "shaka-player": "3.1.0",
-        "@azure/video-analyzer-player": "1.0.3",
+        "@azure/video-analyzer-player": "1.0.4",
         "simplebar": "^5.3.3"
     },
     "files": [

--- a/packages/web-components/src/player-component/shaka.ts
+++ b/packages/web-components/src/player-component/shaka.ts
@@ -30,7 +30,7 @@ export declare namespace shaka {
              */
             getEndByte(): any;
         }
-        class SegmentReference {
+        export class SegmentReference {
             /**
 		 * Creates a SegmentReference, which provides the start time, end time, and
   location to a media segment.
@@ -62,7 +62,7 @@ export declare namespace shaka {
 		 * Returns the segment's start time in seconds, relative to
   the start of a particular Period.
 		 */
-            getStartTime(): any;
+            getStartTime(): number;
             /**
 		 * Returns the segment's end time in seconds, relative to
   the start of a particular Period.
@@ -83,6 +83,8 @@ export declare namespace shaka {
   to the end of the resource.
 		 */
             getEndByte(): any;
+
+            get timestampOffset(): number;
         }
         namespace ManifestParser {
             /**
@@ -118,14 +120,14 @@ export declare namespace shaka {
 		 * @returnType The position of the segment, or null
 	if the position of the segment could not be determined.
 		 */
-            find(time: any): any;
+            find(time: any): number | null;
             /**
 		 * Gets the SegmentReference for the segment at the given position.
 		 * @param position The position of the segment.
 		 * @returnType The SegmentReference, or null if
 	no such SegmentReference exists.
 		 */
-            get(position: any): any;
+            get(position: any): shaka.media.SegmentReference | null;
             /**
 		 * Offset all segment references by a fixed amount.
 		 * @param offset The amount to add to each segment's start and end


### PR DESCRIPTION
Do not display NaN in wall clock when RTCP SR is missing.
Wait till the wall clock time is available before updating the timestamp offset.
Update to the latest @azure/video-analyzer-player for the 'wallclock' event.
Update shaka.ts to expose the required shaka definitions.