### PR TITLE
PBI: 11112223: Temp error handler/reconnect for Widgets, part 1.

### DIFF
--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -24,6 +24,117 @@ import { MimeType } from './player-component.definitions';
 TimelineComponent;
 Localization;
 
+// When using shaka.PlayerInterface.onError to report errors, we sometimes
+// need to be able to pass codes which are not defined in
+// shaka.util.Error.Code.
+enum ErrorCode {
+    WEBSOCKET_CLOSED = 1500, // data = [ CloseEvent.code, CloseEvent.reason, CloseEvent.wasClean ]
+    WEBSOCKET_OPEN = 1501, // data = [ errorMsg, errorObj ]
+}
+
+interface IShakaErrorHandlerConfig {
+    resetSource: () => Promise<void>;
+    autoreconnect?: boolean;
+}
+
+class shakaErrorHandler {
+    private _resetSource: () => Promise<void>;
+    private _autoreconnect: boolean;
+
+    private _firstVideoError = 0;
+    private _numVideoErrors = 0;
+
+    public constructor(config: IShakaErrorHandlerConfig) {
+        this._resetSource = config.resetSource;
+        this._autoreconnect = config.autoreconnect ?? true;
+    }
+
+    // This is async, but caller will
+    // Porting to widgets, had to change from event: Event to event:any
+    // because @types/react declares Event interface which overrides lib.dom.
+    public async onShakaError(event: shaka_player.PlayerEvents.ErrorEvent): Promise<boolean> {
+        if (!('type' in event) || !('detail' in event)) {
+            throw new Error('onShakaError: event not recognized! No type or detail: ' +
+                JSON.stringify(event)
+            );
+        }
+
+        if (event.type !== 'error') {
+            throw new Error(
+                `onShakaError: event not recognized! Type = ${event.type}!`
+            );
+        }
+
+        const shakaError = event.detail as shaka_player.util.Error;
+        if (!shakaError) {
+            throw new Error(
+                'onShakaError: event.detail not provided! ' +
+                `event.type = ${event.type}, ${event}`
+            );
+        }
+
+        // Log the error
+        Logger.error(
+            'onShakaError: code',
+            shakaError.code,
+            `, ${shakaError.message}, object: ${shakaError}`
+        );
+
+        if (shakaError.code === ErrorCode.WEBSOCKET_CLOSED) {
+            if (this._autoreconnect) {
+                if (shakaError.severity === shaka.util.Error.Severity.RECOVERABLE) {
+                    event.stopImmediatePropagation(); // Must call BEFORE await or else dispatch loop will keep notifying
+                    await this._resetSource();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (shakaError.code === 3016) {
+            // VIDEO_ERROR, typically PIPELINE_ERROR_DECODE / VDA Error 4
+            const maxVideoErrors = 10; // Max retries will be 1 less than this number
+            const maxVideoErrorMinutes = 3;
+
+            const now = Date.now();
+            let secondsSinceFirstVideoError = (now - this._firstVideoError) / 1000;
+            if (secondsSinceFirstVideoError > 60 * maxVideoErrorMinutes) {
+                if (this._firstVideoError > 0) {
+                    Logger.log(
+                        `${secondsSinceFirstVideoError} elapsed since first video error, resetting count.`
+                    );
+                }
+                this._numVideoErrors = 0;
+                this._firstVideoError = now;
+                secondsSinceFirstVideoError = 0;
+            }
+
+            this._numVideoErrors += 1;
+            const logMsgPrefix = `Encountered ${this._numVideoErrors} video errors within the last ${secondsSinceFirstVideoError} seconds!`;
+            if (this._numVideoErrors >= maxVideoErrors) {
+                Logger.error(logMsgPrefix, 'No more reloads!');
+                return false;
+            }
+
+            Logger.log(logMsgPrefix, 'Reloading player.');
+            try {
+                event.stopImmediatePropagation(); // Must call BEFORE await or else dispatch loop will keep notifying
+                await this._resetSource();
+                Logger.log('Reload complete!');
+                return true;
+            } catch (e) {
+                Logger.error(`Reload FAILED with error: ${e}`);
+                throw e;
+            }
+        }
+
+        // If we reached this point, we did not recognize and therefore did
+        // not handle the error.
+        return false;
+    }
+}
+
+
 export class PlayerWrapper {
     public player: shaka_player.Player = Object.create(null);
     public resources: IDictionary;
@@ -54,6 +165,7 @@ export class PlayerWrapper {
     private _firstVideoError: number = 0;
     private _numVideoErrors: number = 0;
     private wallclock_event: shaka_player.PlayerEvents.FakeEvent | undefined;
+    private _errorHandler: shakaErrorHandler;
 
     private readonly OFFSET_MULTIPLAYER = 1000;
     private readonly SECONDS_IN_HOUR = 3600;
@@ -384,6 +496,13 @@ export class PlayerWrapper {
             this.allowedControllers
         );
 
+        this._errorHandler = new shakaErrorHandler({
+            resetSource: async () => {
+                const assetUri = this.player.getAssetUri();
+                await this.load(assetUri);
+            }
+        });
+
         // Getting reference to video and video container on DOM
         // Initialize shaka player
         this.player = new shaka.Player(this.video);
@@ -707,49 +826,10 @@ export class PlayerWrapper {
     }
 
     private async onErrorEvent(event: shaka_player.PlayerEvents.ErrorEvent) {
-        // Extract the shaka.util.Error object from the event.
-        // eslint-disable-next-line no-console
-        Logger.log(event.detail);
-
-        // If we encounter a video error, reset video source UNLESS we exceed
-        // max video errors within three minutes.
-        let errorHandled = false;
-        const assetUri = this.player.getAssetUri();
-        if (assetUri.startsWith('ws') && event.detail.code === shaka.util.Error.Code.VIDEO_ERROR) { // code 3016
-            const maxVideoErrors = 10; // Max retries will be 1 less than this number
-            const maxVideoErrorMinutes = 3;
-
-            const now = Date.now();
-            let secondsSinceFirstVideoError = (now - this._firstVideoError) / 1000;
-            if (secondsSinceFirstVideoError > 60 * maxVideoErrorMinutes) {
-                if (this._firstVideoError > 0) {
-                    Logger.log(`${secondsSinceFirstVideoError} elapsed since first video error, resetting count.`);
-                }
-                this._numVideoErrors = 0;
-                this._firstVideoError = now;
-                secondsSinceFirstVideoError = 0;
-            }
-
-            this._numVideoErrors += 1;
-            const logMsgPrefix = `Encountered ${this._numVideoErrors} video errors within the last ${secondsSinceFirstVideoError} seconds!`;
-            if (this._numVideoErrors >= maxVideoErrors) {
-                Logger.error(logMsgPrefix, 'No more reloads!');
-            } else {
-                Logger.log(logMsgPrefix, 'Reloading player.');
-                try {
-                    event.stopImmediatePropagation(); // Must call BEFORE await or else dispatch loop will keep notifying
-                    await this.load(assetUri);
-                    Logger.log('Reload complete!');
-                    errorHandled = true;
-                } catch (e) {
-                    Logger.error('Reload FAILED with error', JSON.stringify(e));
-                }
-            }
-        }
-
+        const errorHandled = await this._errorHandler.onShakaError(event);
         if (!errorHandled && this.errorCallback) {
+            Logger.log(`onErrorEvent: ${event.detail} not handled, calling errorCallback.`);
             this.errorCallback(event);
-            Logger.log(`onErrorEvent: ${event.detail}`);
         }
     }
 

--- a/packages/web-components/src/player-component/shaka.ts
+++ b/packages/web-components/src/player-component/shaka.ts
@@ -5,6 +5,8 @@
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 /* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
+declare class GlobalError extends Error {}
+
 export declare namespace shaka {
     export namespace media {
         export class InitSegmentReference {
@@ -268,8 +270,8 @@ export declare namespace shaka {
             getSeekRangeEnd(): any;
         }
     }
-    namespace util {
-        class Error {
+    export namespace util {
+        class Error extends GlobalError implements shaka.extern.Error {
             severity: any;
             category: any;
             code: any;
@@ -950,7 +952,7 @@ export declare namespace shaka {
         }
     }
 
-    namespace extern {
+    export namespace extern {
         /** define the  TimelineRegionInfo from both doc and code */
         interface TimelineRegionInfo {
             schemeIdUri: string;
@@ -976,6 +978,14 @@ export declare namespace shaka {
             eventDuration: number;
             id: number;
             messageData: Uint8Array;
+        }
+
+        interface Error {
+            category: shaka.util.Error.Category ;
+            code: shaka.util.Error.Code ;
+            data: any [] ;
+            handled: boolean ;
+            severity: shaka.util.Error.Severity ;
         }
     }
 


### PR DESCRIPTION
CR: See pull request.

Originally, I had intended to have Widgets call ShakaRTSP's error
handler/reconnect logic, which was added in PBI # 11064018. It turns
out, this would have been the first time that Widgets had made calls
into ShakaRTSP, and a number of blocking issues arose. Since these
issues will take time to resolve, the quick fix is to simply paste the
code into player.class.ts, and then remove it later when we have
resolved the blocking issues.

Changes
1) Paste the "part 2" version of PBI # 11064018's error handler and
reconnect logic into player.class.ts. During the course of
integration, it was discovered that the return value of
shakaErrorHandler.onShakaError was not useful (it would return true to
indicate that the error was recognized). What we really needed was to
know that it was handled, which is now true with the part 2 change. As
part of this, had to update definitions in shaka.ts. Additionally, had
to modify the code to meet the different lint requirements in this repo.
2) Upgrade to ShakaRTSP version 1.0.4 in order to receive the newer
shaka errors being emitted from rtspManifestParser.ts. Check in
corresponding package-lock.json change.

Testing Procedure
1) Play against b-frame AVA endpoint on Chrome with hardware
acceleration. Filter console log for 3016 (decode error). Confirm
that after 3016, we reconnect and keep playing. This was still true
prior to this change, but re-testing is to confirm that we have not
regressed.
2) Play until server disconnects (or induce temporary network failure).
Restore network. Confirm that we reconnect and keep playing. Prior to
this change, we did not automatically reconnect. Note that this differs
from failure during initial websocket connection: this change does not
modify that. If we encounter failure during initial websocket connection
(bad credentials, bad hostname, bad IP, etc), regardless of this commit,
we will retry 5 times before giving up.