### PR TITLE
Fix retry button behavior and add log for autoreconnect

### DIFF
--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -323,7 +323,13 @@ export class PlayerComponent extends FASTElement {
 
     public retryStreaming() {
         this.clearError();
-        this.player.retryStreaming();
+        if(this.isLive) {
+            Logger.log("Reloading live stream...")
+            this.player.load(this.player.liveStream);
+        } else {
+            Logger.log("Reloading VOD stream...")
+            this.player.load(this.player.vodStream);
+        }
     }
 
     private updateFullScreen() {

--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -323,13 +323,7 @@ export class PlayerComponent extends FASTElement {
 
     public retryStreaming() {
         this.clearError();
-        if(this.isLive) {
-            Logger.log('Reloading live stream...');
-            this.player.load(this.player.liveStream);
-        } else {
-            Logger.log('Reloading VOD stream...');
-            this.player.load(this.player.vodStream);
-        }
+        this.player.retryStreaming();
     }
 
     private updateFullScreen() {

--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -324,10 +324,10 @@ export class PlayerComponent extends FASTElement {
     public retryStreaming() {
         this.clearError();
         if(this.isLive) {
-            Logger.log("Reloading live stream...")
+            Logger.log('Reloading live stream...');
             this.player.load(this.player.liveStream);
         } else {
-            Logger.log("Reloading VOD stream...")
+            Logger.log('Reloading VOD stream...');
             this.player.load(this.player.vodStream);
         }
     }

--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -381,10 +381,10 @@ export class PlayerWrapper {
 
     public retryStreaming() {
         if(this.isLive) {
-            Logger.log("Reloading live stream...")
+            Logger.log('Reloading live stream...');
             this.player.load(this.liveStream);
         } else {
-            Logger.log("Reloading VOD stream...")
+            Logger.log('Reloading VOD stream...');
             this.player.load(this.vodStream);
         }
     }
@@ -541,7 +541,7 @@ export class PlayerWrapper {
         this._errorHandler = new shakaErrorHandler({
             resetSource: async () => {
                 const assetUri = this.player.getAssetUri();
-                Logger.log("Auto-reconnecting...")
+                Logger.log('Auto-reconnecting...');
                 await this.load(assetUri);
             }
         });

--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -380,8 +380,13 @@ export class PlayerWrapper {
     }
 
     public retryStreaming() {
-        this.player.retryStreaming();
-        this.play();
+        if(this.isLive) {
+            Logger.log("Reloading live stream...")
+            this.player.load(this.liveStream);
+        } else {
+            Logger.log("Reloading VOD stream...")
+            this.player.load(this.vodStream);
+        }
     }
 
     private updateLiveButtonState() {
@@ -536,6 +541,7 @@ export class PlayerWrapper {
         this._errorHandler = new shakaErrorHandler({
             resetSource: async () => {
                 const assetUri = this.player.getAssetUri();
+                Logger.log("Auto-reconnecting...")
                 await this.load(assetUri);
             }
         });


### PR DESCRIPTION
The current retry button which appears during the "Errors from the network stack." message (and possibly others) does not work properly. This fix changes the retry behavior from calling shaka's retryStreaming() function to calling a player.load() on whatever asset (live/vod) was playing before the failure. The retryStreaming() function defined in shaka only tries to load the stream if a streaming failure was detected and does nothing otherwise. In most of our failure scenarios, no such streaming failures are reported so the retry button usually does nothing too. The new retry behavior employs the same logic as the auto-reconnect logic already in place to catch websocket closures. 

Also added a log message when auto-reconnecting to differentiate between a manual reconnect from the retry button versus an auto-reconnect.