### PR TITLE
Fix url retrieval to match updated getVideo JSON response schema

### DIFF
--- a/packages/widgets/src/player/player-widget.ts
+++ b/packages/widgets/src/player/player-widget.ts
@@ -133,8 +133,8 @@ export class Player extends BaseWidget {
                     } else {
                         const response = await videoInformation.json();
                         // Init media API
-                        MediaApi.baseStream = response.properties.streaming.archiveBaseUrl;
-                        MediaApi.liveStream = response.properties.streaming.rtspTunnelUrl;
+                        MediaApi.baseStream = response.properties.contentUrls.archiveBaseUrl;
+                        MediaApi.liveStream = response.properties.contentUrls.rtspTunnelUrl;
 
                         // Authorize video
                         await AvaAPi.authorize();


### PR DESCRIPTION
The JSON response schema for the getVideo API call has changed. Previously, the location of the playback URL's was under response.properties.streaming.archiveBaseUrl/rtspTunnelUrl, but now it is response.properties.contentUrls.archiveBaseUrl/rtspTunnelUrl. Updated the way we initialize MediaAPI in order to reflect this change.