### PR TITLE
fix-speed-inf-SA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@azure/video-analyzer-widgets",
-    "version": "2.0.0-alpha.4",
+    "version": "2.0.0-alpha.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
When the meta-data speed is 'inf', show '0.0' instead.