### PR TITLE
prev/next day buttons features

### DIFF
--- a/packages/web-components/src/player-component/UI/ui.class.ts
+++ b/packages/web-components/src/player-component/UI/ui.class.ts
@@ -306,6 +306,7 @@ export class LiveButton extends shaka.ui.Element {
 }
 
 export class NextDayButton extends shaka.ui.Element {
+    public isNextDayButton = true;
     public constructor(parent: any, controls: any, private callBack: () => void) {
         super(parent, controls);
         this.init();
@@ -328,9 +329,13 @@ export class NextDayButton extends shaka.ui.Element {
             this.callBack();
         });
     }
+    public disableNextDayButton(disable: boolean) {
+        this.button_.disabled = disable;
+    }
 }
 
 export class PrevDayButton extends shaka.ui.Element {
+    public isPrevDayButton = true;
     public constructor(parent: any, controls: any, private callBack: () => void) {
         super(parent, controls);
         this.init();
@@ -352,6 +357,9 @@ export class PrevDayButton extends shaka.ui.Element {
         this.eventManager.listen(this.button_, 'click', () => {
             this.callBack();
         });
+    }
+    public disablePrevDayButton(disable: boolean) {
+        this.button_.disabled = disable;
     }
 }
 

--- a/packages/web-components/src/player-component/UI/ui.class.ts
+++ b/packages/web-components/src/player-component/UI/ui.class.ts
@@ -312,6 +312,10 @@ export class NextDayButton extends shaka.ui.Element {
         this.init();
     }
 
+    public disableNextDayButton(disable: boolean) {
+        this.button_.disabled = disable;
+    }
+
     private init() {
         this.button_ = document.createElement('fast-button');
         setElementTooltip(this.button_, Localization.dictionary.BUTTONS_CLASS_NextRecordedDay);
@@ -329,9 +333,6 @@ export class NextDayButton extends shaka.ui.Element {
             this.callBack();
         });
     }
-    public disableNextDayButton(disable: boolean) {
-        this.button_.disabled = disable;
-    }
 }
 
 export class PrevDayButton extends shaka.ui.Element {
@@ -339,6 +340,10 @@ export class PrevDayButton extends shaka.ui.Element {
     public constructor(parent: any, controls: any, private callBack: () => void) {
         super(parent, controls);
         this.init();
+    }
+
+    public disablePrevDayButton(disable: boolean) {
+        this.button_.disabled = disable;
     }
 
     private init() {
@@ -357,9 +362,6 @@ export class PrevDayButton extends shaka.ui.Element {
         this.eventManager.listen(this.button_, 'click', () => {
             this.callBack();
         });
-    }
-    public disablePrevDayButton(disable: boolean) {
-        this.button_.disabled = disable;
     }
 }
 

--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -483,7 +483,7 @@ export class PlayerComponent extends FASTElement {
         }
     }
 
-    private updateNextDayDisabled(): null {
+    private updateNextDayDisabled() {
         const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === this.currentAllowedDays.length - 1) {
             const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
@@ -491,12 +491,11 @@ export class PlayerComponent extends FASTElement {
                 const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
                 if (currentYearIndex === this.currentAllowedYears.length - 1) {
                     this.player.disableNextDayButton(true);
-                    return null;
+                    return;
                 }
             }
         }
         this.player.disableNextDayButton(false);
-        return null;
     }
 
     private async selectNextDay() {
@@ -505,6 +504,9 @@ export class PlayerComponent extends FASTElement {
             const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
             if (currentMonthIndex === this.currentAllowedMonths.length - 1) {
                 const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
+                if (currentYearIndex === this.currentAllowedYears.length - 1) {
+                    return;
+                }
                 this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex + 1], 10);
                 await this.fetchAvailableMonths(this.currentYear);
                 this.currentAllowedMonths = this.allowedDates[this.currentYear];
@@ -547,7 +549,7 @@ export class PlayerComponent extends FASTElement {
         }
     }
 
-    private updatePrevDayDisabled(): null {
+    private updatePrevDayDisabled() {
         const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === 0) {
             const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
@@ -555,12 +557,11 @@ export class PlayerComponent extends FASTElement {
                 const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
                 if (currentYearIndex === 0) {
                     this.player.disablePrevDayButton(true);
-                    return null;
+                    return;
                 }
             }
         }
         this.player.disablePrevDayButton(false);
-        return null;
     }
 
     private async selectPrevDay() {
@@ -569,6 +570,9 @@ export class PlayerComponent extends FASTElement {
             const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
             if (currentMonthIndex === 0) {
                 const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
+                if (currentYearIndex === 0) {
+                    return;
+                }
                 this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex - 1], 10);
                 await this.fetchAvailableMonths(this.currentYear);
                 this.currentAllowedMonths = this.allowedDates[this.currentYear];

--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -483,7 +483,7 @@ export class PlayerComponent extends FASTElement {
         }
     }
 
-    private disableNextDay(): null {
+    private updateNextDayDisabled(): null {
         const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === this.currentAllowedDays.length - 1) {
             const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
@@ -547,7 +547,7 @@ export class PlayerComponent extends FASTElement {
         }
     }
 
-    private disablePrevDay(): null {
+    private updatePrevDayDisabled(): null {
         const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === 0) {
             const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
@@ -612,8 +612,8 @@ export class PlayerComponent extends FASTElement {
     }
 
     private async updateVODStream(VODMode: boolean = false, init = false) {
-        this.disableNextDay();
-        this.disablePrevDay();
+        this.updateNextDayDisabled();
+        this.updatePrevDayDisabled();
         if (!this.afterInit) {
             return;
         }

--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -483,10 +483,50 @@ export class PlayerComponent extends FASTElement {
         }
     }
 
+    private disableNextDay(): null {
+        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        if (currentDayIndex === this.currentAllowedDays.length - 1) {
+            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            if (currentMonthIndex === this.currentAllowedMonths.length - 1) {
+                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
+                if (currentYearIndex === this.currentAllowedYears.length - 1) {
+                    this.player.disableNextDayButton(true);
+                    return null;
+                }
+            }
+        }
+        this.player.disableNextDayButton(false);
+        return null;
+    }
+
     private async selectNextDay() {
+        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        if (currentDayIndex === this.currentAllowedDays.length - 1) {
+            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            if (currentMonthIndex === this.currentAllowedMonths.length - 1) {
+                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
+                this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex + 1]);
+                await this.fetchAvailableMonths(this.currentYear);
+                this.currentAllowedMonths = this.allowedDates[this.currentYear];
+                this.currentMonth = parseInt(this.currentAllowedMonths[0]);
+                await this.fetchAvailableDays(this.currentYear, this.currentMonth);
+                this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
+                this.currentDay = parseInt(this.currentAllowedDays[0]);
+            }
+            else {
+                this.currentMonth =  parseInt(this.currentAllowedMonths[currentMonthIndex + 1]);
+                await this.fetchAvailableDays(this.currentYear, this.currentMonth);
+                this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
+                this.currentDay = parseInt(this.currentAllowedDays[0]);
+            }
+        }
+        else {
+            this.currentDay = parseInt(this.currentAllowedDays[currentDayIndex + 1]);
+        }
+
         // Get next day
-        const startDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay + 1, 0, 0, 0);
-        const untilDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay + 2, 0, 0, 0);
+        const startDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay, 0, 0, 0);
+        const untilDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay + 1, 0, 0, 0);
 
         const start: IExpandedDate = {
             year: startDate.getFullYear(),
@@ -501,18 +541,58 @@ export class PlayerComponent extends FASTElement {
         const segments = await this.fetchAvailableSegments(start, end);
         // eslint-disable-next-line no-console
         if (segments?.timeRanges?.length) {
-            this.currentDay++;
             const date = new Date(Date.UTC(this.currentYear, this.currentMonth - 1, this.currentDay));
             this.currentDate = date;
             this.datePickerComponent.inputDate = date.toUTCString();
+            this.datePickerComponent.date = date;
             this.updateVODStream(true);
         }
     }
 
+    private disablePrevDay(): null {
+        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        if (currentDayIndex === 0) {
+            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            if (currentMonthIndex === 0) {
+                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
+                if (currentYearIndex === 0) {
+                    this.player.disablePrevDayButton(true);
+                    return null;
+                }
+            }
+        }
+        this.player.disablePrevDayButton(false);
+        return null;
+    }
+
     private async selectPrevDay() {
+        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        if (currentDayIndex === 0) {
+            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            if (currentMonthIndex === 0) {
+                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
+                this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex - 1]);
+                await this.fetchAvailableMonths(this.currentYear);
+                this.currentAllowedMonths = this.allowedDates[this.currentYear];
+                this.currentMonth = parseInt(this.currentAllowedMonths[this.currentAllowedMonths.length - 1]);
+                await this.fetchAvailableDays(this.currentYear, this.currentMonth);
+                this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
+                this.currentDay = parseInt(this.currentAllowedDays[this.currentAllowedDays.length - 1]);
+            }
+            else {
+                this.currentMonth =  parseInt(this.currentAllowedMonths[currentMonthIndex - 1]);
+                await this.fetchAvailableDays(this.currentYear, this.currentMonth);
+                this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
+                this.currentDay = parseInt(this.currentAllowedDays[this.currentAllowedDays.length - 1]);
+            }
+        }
+        else {
+            this.currentDay = parseInt(this.currentAllowedDays[currentDayIndex - 1]);
+        }
+
         // Get next day
-        const startDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay - 1, 0, 0, 0);
-        const untilDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay, 0, 0, 0);
+        const startDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay, 0, 0, 0);
+        const untilDate = new Date(this.currentYear, this.currentMonth - 1, this.currentDay + 1, 0, 0, 0);
 
         const start: IExpandedDate = {
             year: startDate.getFullYear(),
@@ -527,15 +607,17 @@ export class PlayerComponent extends FASTElement {
         const segments = await this.fetchAvailableSegments(start, end);
         // eslint-disable-next-line no-console
         if (segments?.timeRanges?.length) {
-            this.currentDay--;
             const date = new Date(Date.UTC(this.currentYear, this.currentMonth - 1, this.currentDay));
             this.currentDate = date;
             this.datePickerComponent.inputDate = date.toUTCString();
+            this.datePickerComponent.date = date;
             this.updateVODStream(true);
         }
     }
 
     private async updateVODStream(VODMode: boolean = false, init = false) {
+        this.disableNextDay();
+        this.disablePrevDay();
         if (!this.afterInit) {
             return;
         }

--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -484,11 +484,11 @@ export class PlayerComponent extends FASTElement {
     }
 
     private disableNextDay(): null {
-        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === this.currentAllowedDays.length - 1) {
-            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
             if (currentMonthIndex === this.currentAllowedMonths.length - 1) {
-                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
+                const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
                 if (currentYearIndex === this.currentAllowedYears.length - 1) {
                     this.player.disableNextDayButton(true);
                     return null;
@@ -500,28 +500,26 @@ export class PlayerComponent extends FASTElement {
     }
 
     private async selectNextDay() {
-        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === this.currentAllowedDays.length - 1) {
-            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
             if (currentMonthIndex === this.currentAllowedMonths.length - 1) {
-                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
-                this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex + 1]);
+                const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
+                this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex + 1], 10);
                 await this.fetchAvailableMonths(this.currentYear);
                 this.currentAllowedMonths = this.allowedDates[this.currentYear];
-                this.currentMonth = parseInt(this.currentAllowedMonths[0]);
+                this.currentMonth = parseInt(this.currentAllowedMonths[0], 10);
                 await this.fetchAvailableDays(this.currentYear, this.currentMonth);
                 this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
-                this.currentDay = parseInt(this.currentAllowedDays[0]);
-            }
-            else {
-                this.currentMonth =  parseInt(this.currentAllowedMonths[currentMonthIndex + 1]);
+                this.currentDay = parseInt(this.currentAllowedDays[0], 10);
+            } else {
+                this.currentMonth =  parseInt(this.currentAllowedMonths[currentMonthIndex + 1], 10);
                 await this.fetchAvailableDays(this.currentYear, this.currentMonth);
                 this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
-                this.currentDay = parseInt(this.currentAllowedDays[0]);
+                this.currentDay = parseInt(this.currentAllowedDays[0], 10);
             }
-        }
-        else {
-            this.currentDay = parseInt(this.currentAllowedDays[currentDayIndex + 1]);
+        } else {
+            this.currentDay = parseInt(this.currentAllowedDays[currentDayIndex + 1], 10);
         }
 
         // Get next day
@@ -550,11 +548,11 @@ export class PlayerComponent extends FASTElement {
     }
 
     private disablePrevDay(): null {
-        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === 0) {
-            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
             if (currentMonthIndex === 0) {
-                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
+                const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
                 if (currentYearIndex === 0) {
                     this.player.disablePrevDayButton(true);
                     return null;
@@ -566,28 +564,26 @@ export class PlayerComponent extends FASTElement {
     }
 
     private async selectPrevDay() {
-        let currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item) === this.currentDay);
+        const currentDayIndex = this.currentAllowedDays.findIndex(item => parseInt(item, 10) === this.currentDay);
         if (currentDayIndex === 0) {
-            let currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item) === this.currentMonth);
+            const currentMonthIndex = this.currentAllowedMonths.findIndex(item => parseInt(item, 10) === this.currentMonth);
             if (currentMonthIndex === 0) {
-                let currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item) === this.currentYear);
-                this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex - 1]);
+                const currentYearIndex = this.currentAllowedYears.findIndex(item => parseInt(item, 10) === this.currentYear);
+                this.currentYear = parseInt(this.currentAllowedYears[currentYearIndex - 1], 10);
                 await this.fetchAvailableMonths(this.currentYear);
                 this.currentAllowedMonths = this.allowedDates[this.currentYear];
-                this.currentMonth = parseInt(this.currentAllowedMonths[this.currentAllowedMonths.length - 1]);
+                this.currentMonth = parseInt(this.currentAllowedMonths[this.currentAllowedMonths.length - 1], 10);
                 await this.fetchAvailableDays(this.currentYear, this.currentMonth);
                 this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
-                this.currentDay = parseInt(this.currentAllowedDays[this.currentAllowedDays.length - 1]);
-            }
-            else {
-                this.currentMonth =  parseInt(this.currentAllowedMonths[currentMonthIndex - 1]);
+                this.currentDay = parseInt(this.currentAllowedDays[this.currentAllowedDays.length - 1], 10);
+            } else {
+                this.currentMonth =  parseInt(this.currentAllowedMonths[currentMonthIndex - 1], 10);
                 await this.fetchAvailableDays(this.currentYear, this.currentMonth);
                 this.currentAllowedDays = this.allowedDates[this.currentYear][this.currentMonth];
-                this.currentDay = parseInt(this.currentAllowedDays[this.currentAllowedDays.length - 1]);
+                this.currentDay = parseInt(this.currentAllowedDays[this.currentAllowedDays.length - 1], 10);
             }
-        }
-        else {
-            this.currentDay = parseInt(this.currentAllowedDays[currentDayIndex - 1]);
+        } else {
+            this.currentDay = parseInt(this.currentAllowedDays[currentDayIndex - 1], 10);
         }
 
         // Get next day

--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -418,6 +418,22 @@ export class PlayerWrapper {
         }
     }
 
+    public disableNextDayButton(disable: boolean) {
+        for (const element of this.controls?.elements_) {
+            if (element?.isNextDayButton) {
+                element.disableNextDayButton(disable);
+            }
+        }
+    }
+
+    public disablePrevDayButton(disable: boolean) {
+        for (const element of this.controls?.elements_) {
+            if (element?.isPrevDayButton) {
+                element.disablePrevDayButton(disable);
+            }
+        }
+    }
+
     private updateLiveButtonState() {
         for (const element of this.controls?.elements_) {
             if (element?.isLiveButton) {


### PR DESCRIPTION
* Go to the previous or next day which has a video available by clicking the prev/next day buttons. (skip the gaps)
* If the day is the first/last day of the whole record, disable the button.
* Fix the bug for the fetching error when going between days from one month to another.