### PR TITLE
Only enable drift correction for RTSP live

### DIFF
--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -269,7 +269,7 @@ export class PlayerWrapper {
         this.isLoaded = false;
         this.timestampOffset = undefined;
         try {
-            if (url.indexOf('wss:/') != -1) {
+            if (url.startsWith('ws')) {
                 this.updateParentClass('rtsp-playback', true);
                 this._rtspPlayback= true;
             } else {

--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -154,6 +154,7 @@ export class PlayerWrapper {
     private _driftCorrectionTimer: number | null = null;
     private wallclock_event: shaka_player.PlayerEvents.FakeEvent | undefined;
     private _errorHandler: shakaErrorHandler;
+    private _rtspPlayback: boolean = false;
 
     private readonly OFFSET_MULTIPLAYER = 1000;
     private readonly SECONDS_IN_HOUR = 3600;
@@ -270,8 +271,10 @@ export class PlayerWrapper {
         try {
             if (url.indexOf('wss:/') != -1) {
                 this.updateParentClass('rtsp-playback', true);
+                this._rtspPlayback= true;
             } else {
                 this.updateParentClass('rtsp-playback', false);
+                this._rtspPlayback = false;
             }
 
             await this.player.load(url, null, this.getMimeType(url));
@@ -680,7 +683,7 @@ export class PlayerWrapper {
         const MAX_LATENCY_WINDOW = 3; // in seconds
         this._driftCorrectionTimer = window.setInterval(async () => {
             const video = this.player.getMediaElement() as HTMLMediaElement;
-            if (video && !video.paused && this.isLive && !this.player.isBuffering()) {
+            if (video && !video.paused && this._rtspPlayback && !this.player.isBuffering()) {
                 const videoBuffered = this.player.getBufferedInfo().video;
                 const videoCurrentTime = video.currentTime; // Lock in the current value
                 const videoBufferedEnd = videoBuffered.length > 0 ? videoBuffered[videoBuffered.length - 1].end : videoCurrentTime - 1;


### PR DESCRIPTION
this.isLive was being used to determine whether we were playing RTSP or vod for the purposes of drift correction but this value is true for both RTSP and high latency live. However, we only want to enable drift correction for RTSP playback. Added a new flag, _rtspPlayback, to indicate whether or not the current playback session is RTSP or vod and use this value to determine whether or not to enable drift correction. 