### PR TITLE
Disable looping which reach the end of the last segment of the day

### DIFF
--- a/packages/common/services/media/media-api.class.ts
+++ b/packages/common/services/media/media-api.class.ts
@@ -59,7 +59,7 @@ export class MediaApi {
         if (range) {
             const startDay = this.convertDateToIso(range.start.year, range.start.month, range.start.day);
             if (range.end) {
-                const endDay = this.convertDateToIso(range.end.year, range.end.month, range.end.day);
+                const endDay = this.convertDateToIso(range.end.year, range.end.month, range.end.day - 1) + 'T23:59:59.000Z';
                 range_query = `,starttime=${startDay},endtime=${endDay}`;
             } else {
                 range_query = `,starttime=${startDay}`;

--- a/packages/common/services/media/media-api.class.ts
+++ b/packages/common/services/media/media-api.class.ts
@@ -59,7 +59,7 @@ export class MediaApi {
         if (range) {
             const startDay = this.convertDateToIso(range.start.year, range.start.month, range.start.day);
             if (range.end) {
-                const endDay = this.convertDateToIso(range.end.year, range.end.month, range.end.day - 1) + 'T23:59:59.000Z';
+                const endDay = new Date(Date.UTC(range.end.year, range.end.month - 1, range.end.day - 1)).toISOString().slice(0, 10) + 'T23:59:58.999Z';
                 range_query = `,starttime=${startDay},endtime=${endDay}`;
             } else {
                 range_query = `,starttime=${startDay}`;


### PR DESCRIPTION
The scenario is that only when the record's last segment of the day reaches the last second of the day, it will loop back to the beginning of the day's first segment. That is because the widget requests for the VOD stream from the start of the current day to the start of the next day (next day 00:00:00) (accurate to day) which causes the looping. This PR is a possible solution for this: when requesting for the VOD stream, for the end time of the time range, instead of using the next day (accurate to day), use the last second of the current day (accurate to second, ex. 23:59:59).