### PR TITLE
fix segment button bug

### DIFF
--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -453,6 +453,7 @@ export class PlayerWrapper {
         const segmentEventData = event.detail;
         if (segmentEventData) {
             this.currentSegment = event.detail.segment;
+            this.updatePrevNextSegmentButtonsDisabledState();
             const newCurrentTime = event.detail.time + this.getVideoOffset();
             Logger.log(`onSegmentChange: jump to ${newCurrentTime}, ` + this.getSeekRangeString());
             this.video.currentTime = newCurrentTime;


### PR DESCRIPTION
When the user manually selects a position of a segment in the timeline bar, the prev/next buttons will also update.