### PR TITLE
keep zoom level when navigating through days and recreate the timelin…

### DIFF
--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -342,10 +342,11 @@ export class PlayerComponent extends FASTElement {
                 this.currentYear = this.currentDate.getUTCFullYear();
                 this.currentMonth = this.currentDate.getUTCMonth() + 1;
                 this.currentDay = this.currentDate.getUTCDate();
+                const isClipBeforeSelectDate = this.isClip;
                 this.isClip = false;
 
                 this.updateVODStream(true);
-                if (this.player) {
+                if (this.player && isClipBeforeSelectDate) {
                     this.player?.toggleClipMode(this.isClip);
                 }
             }

--- a/packages/web-components/src/player-component/player.class.ts
+++ b/packages/web-components/src/player-component/player.class.ts
@@ -56,6 +56,7 @@ export class PlayerWrapper {
     private _driftCorrectionTimer: number | null = null;
     private wallclock_event: shaka_player.PlayerEvents.FakeEvent | undefined;
     private _errorHandler: ShakaErrorHandler;
+    private _timelineComponentZoom: number;
 
     private readonly OFFSET_MULTIPLAYER = 1000;
     private readonly SECONDS_IN_HOUR = 3600;
@@ -747,8 +748,10 @@ export class PlayerWrapper {
             this.getClockTimeString(displayTime);
 
             // Update timeline
+            this._timelineComponentZoom = this.timelineComponent?.zoom;
             this.removeTimelineComponent();
             this.createTimelineComponent();
+            this.timelineComponent.zoom = this._timelineComponentZoom || this.timelineComponent.DEFAULT_ZOOM_LEVEL;
         } else {
             // Wrap range element and add time tooltip
             this.avaUILayer.addLiveSeekBarTooltip(this.controls, this.computeClockForLive.bind(this));


### PR DESCRIPTION
…e component only once instead of twice

* Keep zoom level when navigating through days. (Click prev/next day button or use datepicker to select a date)
* Recreate the timeline component only once instead of twice.

In the previous version, when we select a date in the datepicker, the timeline component will be created twice which maybe not the desired behavior.
In 'player-component.ts' (line 349), function 'initDatePicker', we should not remove the code to call the 'toggleClipMode', because if we first give the widget a clip input, and then, select a date in the datepicker, there will be no timeline-component to be created.
There are two scenarios when we select a date in the datepicker calendar: 
a. clip mode -> regular VOD mode
b. regular VOD mode -> regular VOD mode
For scenario a, we need to call the toggleClipMode to create the timeline component.
For scenario b, we should do nothing, because function 'onTrackChange' in 'player.class.ts'(line 733) will listen to the change of the day and update the timeline component once.