### PR TITLE
fix-video-cut-in-fullscreen-mode-by-reduce-max-video-height

### DIFF
--- a/packages/web-components/src/player-component/player-component.style.ts
+++ b/packages/web-components/src/player-component/player-component.style.ts
@@ -278,6 +278,10 @@ export const styles = css`
         background: black;
     }
 
+    .fullscreen video {
+        max-height: calc(100% - ${bottomControlHeight} - ${timelineHeight});
+    }
+
     .upper-bounding {
         padding: 0 20px;
         height: 49px;


### PR DESCRIPTION
Another solution to fix video cut in fullscreen mode.
Add max-height attribute to video in fullscreen mode to make sure all the video content will be shown.