### PR TITLE
fix datepicker not showing correct date bug in clip mode

### DIFF
--- a/packages/web-components/src/player-component/player-component.ts
+++ b/packages/web-components/src/player-component/player-component.ts
@@ -256,6 +256,11 @@ export class PlayerComponent extends FASTElement {
 
         this.currentDate = date;
         this.datePickerComponent.inputDate = date.toUTCString();
+
+        if (this.isClip) {
+            this.currentDate = this.clipTimeRange.startTime;
+            this.datePickerComponent.date = this.clipTimeRange.startTime;
+        }
     }
 
     public cameraNameChanged() {


### PR DESCRIPTION
Fix bug: Bug 12798488: Datepicker calendar is not showing the correct date in clip mode.