### PR TITLE
Enable to pick the same day in datepicker

### DIFF
--- a/packages/web-components/src/date-picker/date-picker.component.ts
+++ b/packages/web-components/src/date-picker/date-picker.component.ts
@@ -265,6 +265,6 @@ export class DatePickerComponent extends FASTElement {
     }
 
     private onDateOpen() {
-        this.datePicker.picker.set('select', this.date);
+        //This function will be called when clicking the datepicker icon to open the calendar.
     }
 }

--- a/packages/web-components/src/date-picker/date-picker.component.ts
+++ b/packages/web-components/src/date-picker/date-picker.component.ts
@@ -265,6 +265,6 @@ export class DatePickerComponent extends FASTElement {
     }
 
     private onDateOpen() {
-        //This function will be called when clicking the datepicker icon to open the calendar.
+        // This function will be called when clicking the datepicker icon to open the calendar.
     }
 }


### PR DESCRIPTION
This PR enables to pick the same day in datepicker. (Go to VOD mode, to the beginning of the day.)
* Findings: Calling **updateVODSteam** multiple times will crash the widget.
* Avoid adding the '**DatePickerEvent.DATE_CHANGE**' event listener twice.
* The listener is added twice because the datepicker is inited twice. (Make it init only once.)
* Remove the precondition of the date is changed to call **updateVODStream** in '**DatePickerEvent.DATE_CHANGE**' event listener to enable to pick the same day.
* After removing the precondition, be careful about the situations that call the **updateVODStream** multiple times.
* Covered all the situations and make sure the **updateVODStream** is called no more than once.