### PR TITLE
Ensure every ARIA input field has an accessible name

### DIFF
--- a/packages/web-components/src/timeline/timeline.template.ts
+++ b/packages/web-components/src/timeline/timeline.template.ts
@@ -51,7 +51,7 @@ export const template = html<TimelineComponent>`
                         connectedCallback="${(x) => x.fastSliderConnectedCallback()}"
                         aria-label="zoom-slider"
                         role="slider"
-                        aria-valuenow="${(x) => x.fastSlider?.value}"
+                        aria-valuenow="32"
                     >
                         <svg class="fast-slider-svg" slot="thumb">
                             <path class="marker-bg-path" d="${ZOOM_MARKER_BG_PATH}"></path>

--- a/packages/web-components/src/timeline/timeline.template.ts
+++ b/packages/web-components/src/timeline/timeline.template.ts
@@ -46,7 +46,11 @@ export const template = html<TimelineComponent>`
                             <path d="${ZOOM_MINUS_PATH}"></path>
                         </svg>
                     </fast-button>
-                    <fast-slider class="zoom-slider" connectedCallback="${(x) => x.fastSliderConnectedCallback()}">
+                    <fast-slider
+                        class="zoom-slider"
+                        connectedCallback="${(x) => x.fastSliderConnectedCallback()}"
+                        aria-label="zoom-slider"
+                    >
                         <svg class="fast-slider-svg" slot="thumb">
                             <path class="marker-bg-path" d="${ZOOM_MARKER_BG_PATH}"></path>
                             <path class="marker-path" d="${ZOOM_MARKER_PATH}"></path>

--- a/packages/web-components/src/timeline/timeline.template.ts
+++ b/packages/web-components/src/timeline/timeline.template.ts
@@ -51,7 +51,7 @@ export const template = html<TimelineComponent>`
                         connectedCallback="${(x) => x.fastSliderConnectedCallback()}"
                         aria-label="zoom-slider"
                         role="slider"
-                        aria-valuenow="32"
+                        aria-valuenow="${(x) => x.fastSlider?.value || `${x.zoom * x.SLIDER_DENSITY}`}"
                     >
                         <svg class="fast-slider-svg" slot="thumb">
                             <path class="marker-bg-path" d="${ZOOM_MARKER_BG_PATH}"></path>

--- a/packages/web-components/src/timeline/timeline.template.ts
+++ b/packages/web-components/src/timeline/timeline.template.ts
@@ -51,6 +51,7 @@ export const template = html<TimelineComponent>`
                         connectedCallback="${(x) => x.fastSliderConnectedCallback()}"
                         aria-label="zoom-slider"
                         role="slider"
+                        aria-valuenow="${(x) => x.fastSlider.value}"
                     >
                         <svg class="fast-slider-svg" slot="thumb">
                             <path class="marker-bg-path" d="${ZOOM_MARKER_BG_PATH}"></path>

--- a/packages/web-components/src/timeline/timeline.template.ts
+++ b/packages/web-components/src/timeline/timeline.template.ts
@@ -51,7 +51,7 @@ export const template = html<TimelineComponent>`
                         connectedCallback="${(x) => x.fastSliderConnectedCallback()}"
                         aria-label="zoom-slider"
                         role="slider"
-                        aria-valuenow="${(x) => x.fastSlider.value}"
+                        aria-valuenow="${(x) => x.fastSlider?.value}"
                     >
                         <svg class="fast-slider-svg" slot="thumb">
                             <path class="marker-bg-path" d="${ZOOM_MARKER_BG_PATH}"></path>

--- a/packages/web-components/src/timeline/timeline.template.ts
+++ b/packages/web-components/src/timeline/timeline.template.ts
@@ -50,6 +50,7 @@ export const template = html<TimelineComponent>`
                         class="zoom-slider"
                         connectedCallback="${(x) => x.fastSliderConnectedCallback()}"
                         aria-label="zoom-slider"
+                        role="slider"
                     >
                         <svg class="fast-slider-svg" slot="thumb">
                             <path class="marker-bg-path" d="${ZOOM_MARKER_BG_PATH}"></path>


### PR DESCRIPTION
Fix bug: Bug 11013439: [Programmatic Access - Azure Video Analyzer - Video analyzer]: Ensures every ARIA input field has an accessible name (ava-player,media-player,#cce58e8a-0322-688a-8bf7-c3b7969b6442,fast-slider)