### PR TITLE
Ensures buttons have discernible text

### DIFF
--- a/packages/web-components/src/player-component/UI/ui.class.ts
+++ b/packages/web-components/src/player-component/UI/ui.class.ts
@@ -432,6 +432,7 @@ export class NextSegment extends shaka.ui.Element {
     private init() {
         this.button_ = document.createElement('fast-button');
         this.button_.setAttribute('title', Localization.dictionary.BUTTONS_CLASS_NextTimeRange);
+        this.button_.ariaLabel = Localization.dictionary.BUTTONS_CLASS_NextTimeRange;
         // Create SVG
         this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         this.path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
@@ -461,6 +462,7 @@ export class PrevSegment extends shaka.ui.Element {
     private init() {
         this.button_ = document.createElement('fast-button');
         this.button_.setAttribute('title', Localization.dictionary.BUTTONS_CLASS_PreviousTimeRange);
+        this.button_.ariaLabel = Localization.dictionary.BUTTONS_CLASS_PreviousTimeRange;
         // Create SVG
         this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         this.path = document.createElementNS('http://www.w3.org/2000/svg', 'path');


### PR DESCRIPTION
Fix bug: Bug 11013386: [Programmatic Access - Azure Video Analyzer - Video analyzer]: Ensures buttons have discernible text (ava-player,media-player,.next-segment-button,.icon-only.control[value=""])