### PR TITLE
Focus visible for zoom slider using keyboard

### DIFF
--- a/packages/web-components/src/timeline/timeline.style.ts
+++ b/packages/web-components/src/timeline/timeline.style.ts
@@ -105,6 +105,10 @@ export const styles = css`
         border: 1px solid var(--bg-dialog);
     }
 
+    .zoom-slider:focus-visible {
+        border: 2px solid var(--neutral-focus);
+    }
+
     .reset-button {
         right: 0px;
     }


### PR DESCRIPTION
Fix for bug: Bug 11013678: [Keyboard navigation - Azure Video Analyzer - Video analyzer]: Keyboard focus lost after Zoom out button under video section.