### PR TITLE
Ensure buttons have discernible text datePicker button

### DIFF
--- a/packages/web-components/src/date-picker/date-picker.template.ts
+++ b/packages/web-components/src/date-picker/date-picker.template.ts
@@ -10,7 +10,11 @@ export const template = html<DatePickerComponent>`
     <template>
         <div class="ms-DatePicker ${(x) => (x.enableUI ? 'show' : 'hide')} ${(x) => (x.alignRight ? 'right' : '')}">
             <div class="ms-TextField">
-                <fast-button class="ms-TextField-field" appearance="stealth">
+                <fast-button
+                    class="ms-TextField-field"
+                    appearance="stealth"
+                    aria-label="datePicker-button"
+                >
                     <svg>
                         <path d="${GO_TO_ARCHIVE_MAIN_SVG_PATH}"></path>
                         <path d="${GO_TO_ARCHIVE_SUB_SVG_PATH}"></path>


### PR DESCRIPTION
Fix programmatic access bug for datePicker button.

Path: "ava-player,media-player,media-date-picker,#P706159617,button[value="\32 1\ September\,\ 2021"]"
Snippet: "< button class="control icon-only" part="control" value="21 September, 2021" type="text" aria-haspopup="true" aria-expanded="false" aria-owns="P706159617_root" >".

