### PR TITLE
Fix datepicker button focus to open.

### DIFF
--- a/packages/scripts/picker.ts
+++ b/packages/scripts/picker.ts
@@ -697,10 +697,10 @@
             // If it’s a focus event, add the “focused” class to the root.
             if (event.type == 'focus') {
                 P.$root.addClass(CLASSES.focused);
+            } else {
+               // If the event is focus, should not open the picker.
+                P.open(); 
             }
-
-            // And then finally open the picker.
-            P.open();
         }
 
         // Return a new picker instance.


### PR DESCRIPTION
Fix bug: Bug 11013637: [Keyboard navigation - Azure Video Analyzer - Video analyzer]: Calendar pop up open automatically after pressing tab key.